### PR TITLE
Update CKAN base images to version 2.10.6 in Dockerfiles

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.5
+FROM ckan/ckan-base:2.10.6
 
 # Install any extensions needed by your CKAN instance
 # See Dockerfile.dev for more details and examples

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.5
+FROM ckan/ckan-dev:2.10.6
 
 # Install any extensions needed by your CKAN instance
 # - Make sure to add the plugins to CKAN__PLUGINS in the .env file


### PR DESCRIPTION
Hey guys,

There has been a patch release for CKAN 2.10.6
https://docs.ckan.org/en/2.10/changelog.html#v-2-10-6-2024-12-11


