### PR TITLE
Upgrade to CKAN 2.10.6

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.5
+FROM ckan/ckan-base:2.10.6
 
 # Install any extensions needed by your CKAN instance
 # See Dockerfile.dev for more details and examples

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.5
+FROM ckan/ckan-dev:2.10.6
 
 # Install any extensions needed by your CKAN instance
 # - Make sure to add the plugins to CKAN__PLUGINS in the .env file


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles used for building and developing the CKAN instance. The base images have been updated to the latest version.

Updates to Dockerfiles:

* [`ckan/Dockerfile`](diffhunk://#diff-2255ee862e56fe4f21e684dd00e9f290aebbc3fbb7ac11a56c21ade18cff6f3aL1-R1): Updated the base image from `ckan/ckan-base:2.10.5` to `ckan/ckan-base:2.10.6`.
* [`ckan/Dockerfile.dev`](diffhunk://#diff-b2e36077067a18b5db19a15f820507bf15e816b80363e788edd5a26d5273b611L1-R1): Updated the base image from `ckan/ckan-dev:2.10.5` to `ckan/ckan-dev:2.10.6`.