### PR TITLE
Upgrade to CKAN 2.10.7

### DIFF
--- a/.env.dbca
+++ b/.env.dbca
@@ -35,7 +35,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.0
+CKAN_VERSION=2.10.7
 CKAN_SITE_ID=default
 # CKAN Dev
 CKAN_SITE_URL=http://localhost:$CKAN_PORT_HOST

--- a/.env.dbca
+++ b/.env.dbca
@@ -89,8 +89,8 @@ CKANEXT__SPATIAL__COMMON_MAP__APIKEY=
 
 ## ckanext-saml2auth ##
 # # Staging
-# CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH=/srv/app/saml/dbca_staging_idp.xml
-# CKANEXT__SAML2AUTH__ENTITY_ID=urn:mace:umu.se:saml:ckan_dbca_staging:sp
+CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH=/srv/app/saml/dbca_staging_idp.xml
+CKANEXT__SAML2AUTH__ENTITY_ID=urn:mace:umu.se:saml:ckan_dbca_staging:sp
 # # Production
 # CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH=/srv/app/saml/dbca_prod_idp.xml
 # CKANEXT__SAML2AUTH__ENTITY_ID=urn:mace:umu.se:saml:ckan_dbca_prod:sp

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.0
+CKAN_VERSION=2.10.7
 CKAN_SITE_ID=default
 CKAN_SITE_URL=https://localhost:8443
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME

--- a/.github/workflows/dbca_build.yml
+++ b/.github/workflows/dbca_build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Extract first tag
         id: extract_first_tag
-        run: echo "::set-output name=first_tag::$(echo ${{ steps.meta_ckan.outputs.tags }} | cut -d ',' -f 1)"
+        run: echo "first_tag=$(echo ${{ steps.meta_ckan.outputs.tags }} | cut -d ',' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Use first tag
         run: echo "Using image ref ghcr.io/dbca-wa/ckan-docker-ckan:${{ steps.extract_first_tag.outputs.first_tag }}"

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.6
+FROM ckan/ckan-base:2.10.7
 
 # Install any extensions needed by your CKAN instance
 # See Dockerfile.dev for more details and examples

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.6
+FROM ckan/ckan-dev:2.10.7
 
 # Install any extensions needed by your CKAN instance
 # - Make sure to add the plugins to CKAN__PLUGINS in the .env file

--- a/ckan/setup/dbca_requirements.sh
+++ b/ckan/setup/dbca_requirements.sh
@@ -10,6 +10,9 @@ pip3 install -r ${SRC_DIR}/ckanext-archiver/requirements.txt
 pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v1.5.1#egg=ckanext-dcat
 pip3 install -r ${SRC_DIR}/ckanext-dcat/requirements.txt
 
+# Geoview
+pip3 install -e git+https://github.com/ckan/ckanext-geoview.git@v0.1.0#egg=ckanext-geoview
+
 # Hierarchy
 pip3 install -e git+https://github.com/ckan/ckanext-hierarchy.git@v1.2.1#egg=ckanext-hierarchy
 pip3 install -r ${SRC_DIR}/ckanext-hierarchy/requirements.txt
@@ -21,11 +24,15 @@ pip3 install -e git+https://github.com/ckan/ckanext-pages.git@v0.5.2#egg=ckanext
 pip3 install -e git+https://github.com/ckan/ckanext-pdfview.git@0.0.8#egg=ckanext-pdfview
 
 # Report
-pip3 install -e git+http://github.com/ckan/ckanext-report.git@master#egg=ckanext-report --exists-action i
+pip3 install -e git+https://github.com/ckan/ckanext-report.git@master#egg=ckanext-report --exists-action i
 pip3 install -r ${SRC_DIR}/ckanext-report/requirements.txt
 
 # Scheming
 pip3 install -e git+https://github.com/ckan/ckanext-scheming.git@release-3.0.0#egg=ckanext-scheming
+
+# Showcase
+pip3 install -e git+https://github.com/ckan/ckanext-showcase.git@v1.8.3#egg=ckanext-showcase
+pip3 install -r ${SRC_DIR}/ckanext-showcase/requirements.txt
 
 # Spatial
 # dependencies
@@ -43,9 +50,6 @@ pip3 install -r ${SRC_DIR}/ckanext-spatial/requirements.txt
 # XLoader
 pip3 install -e git+https://github.com/ckan/ckanext-xloader.git@1.0.1#egg=ckanext-xloader
 pip3 install -r ${SRC_DIR}/ckanext-xloader/requirements.txt
-
-# Geoview
-pip3 install -e git+https://github.com/ckan/ckanext-geoview.git@v0.1.0#egg=ckanext-geoview
 
 
 ## 3rd Party ##
@@ -74,8 +78,3 @@ rm /tmp/qsv.zip
 apk add file
 pip3 install -e git+https://github.com/dbca-wa/ckanext-qa.git@develop#egg=ckanext-qa
 pip3 install -r ${SRC_DIR}/ckanext-qa/requirements.txt
-
-# # Showcase
-# Temporary use of Salsa Digital's fork of ckanext-showcase
-pip3 install -e git+https://github.com/salsadigitalauorg/ckanext-showcase.git@master#egg=ckanext-showcase
-pip3 install -r ${SRC_DIR}/ckanext-showcase/requirements.txt


### PR DESCRIPTION
This pull request includes updates to the CKAN version and related configurations across several files. The changes ensure that the CKAN version is consistently updated to 2.10.7 and adjust related settings.

CKAN version updates:

* Updated `CKAN_VERSION` to 2.10.7 in `.env.dbca` and `.env.example` files. [[1]](diffhunk://#diff-0f9ecf57278a460a375662d3129642c8434090c21f4012dab804e513363b7bc2L38-R38) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL30-R30)
* Updated the CKAN base image to 2.10.7 in `ckan/Dockerfile`.
* Updated the CKAN development image to 2.10.7 in `ckan/Dockerfile.dev`.

Configuration adjustments:

* Uncommented and updated `CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH` and `CKANEXT__SAML2AUTH__ENTITY_ID` for staging in `.env.dbca`.