### PR TITLE
[SD-6342] added upload limit

### DIFF
--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -75,13 +75,17 @@ ckanext-archiver.cache_url_root=/resource_cache/
 ckanext.qa.qsv_bin=/usr/local/bin/qsv
 
 # ckanext-dbca
+ckan.max_resource_size = 150
+ckanext.dbca.sysadmin_resource_upload_limit = 150
+ckanext.dbca.org_admin_resource_upload_limit = 35
+ckanext.dbca.org_editor_resource_upload_limit = 35
 ckanext.dbca.spatial_data_path = /srv/app/spatial_data
-ckanext.dbca.spatial_data_mappings = 
+ckanext.dbca.spatial_data_mappings =
     {
-        "ibra.geojson": {"layer": "IBRA Regions", "code":"IWA_REG_CODE_7", "name":"IWA_REG_NAME_7"}, 
-        "ibra-sub.geojson": {"layer": "IBRA Subregions", "code":"IWA_SUB_CODE_7", "name":"IWA_SUB_NAME_7"}, 
-        "imcra.geojson": {"layer": "IMCRA Regions", "code": "MESO_ABBR", "name":"MESO_NAME"}, 
-        "lga-wa.geojson": {"layer": " Local Government Areas", "code":"LGA_TYPE", "name":"LGA_LGA_NAME"}, 
+        "ibra.geojson": {"layer": "IBRA Regions", "code":"IWA_REG_CODE_7", "name":"IWA_REG_NAME_7"},
+        "ibra-sub.geojson": {"layer": "IBRA Subregions", "code":"IWA_SUB_CODE_7", "name":"IWA_SUB_NAME_7"},
+        "imcra.geojson": {"layer": "IMCRA Regions", "code": "MESO_ABBR", "name":"MESO_NAME"},
+        "lga-wa.geojson": {"layer": " Local Government Areas", "code":"LGA_TYPE", "name":"LGA_LGA_NAME"},
         "tenure.geojson": {"layer": "DBCA Managed Tenure", "code":"LEG_TENURE", "name":"LEG_NAME"}
     }
 


### PR DESCRIPTION
https://servicedesk.salsadigital.com.au/a/tickets/6342

Initially, I didn't use `ckanext.dbca.sysadmin_resource_upload_limit`; sysadmins were governed by `ckan.max_resource_size`. However, I realized there could be cases where the sysadmin limit is lower than other user roles. 

To handle this properly, I ended up defining four configurable variables.