### PR TITLE
[SD-6426] upgrade to latest ckan 2.10.8

### DIFF
--- a/.env.dbca
+++ b/.env.dbca
@@ -35,7 +35,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.7
+CKAN_VERSION=2.10.8
 CKAN_SITE_ID=default
 # CKAN Dev
 CKAN_SITE_URL=http://localhost:$CKAN_PORT_HOST

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.7
+CKAN_VERSION=2.10.8
 CKAN_SITE_ID=default
 CKAN_SITE_URL=https://localhost:8443
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ For convenience the CKAN_SITE_URL parameter should be set in the .env file. For 
 
 ## 12. Changing the base image
 
-The base image used in the CKAN Dockerfile and Dockerfile.dev can be changed so a different DockerHub image is used eg: ckan/ckan-base:2.10.5 can be used instead of ckan/ckan-base:2.11.0
+The base image used in the CKAN Dockerfile and Dockerfile.dev can be changed so a different DockerHub image is used eg: ckan/ckan-base:2.10.8 can be used instead of ckan/ckan-base:2.11.0
 
 ## 13. Replacing DataPusher with XLoader
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.7
+FROM ckan/ckan-base:2.10.8
 
 # Install any extensions needed by your CKAN instance
 # See Dockerfile.dev for more details and examples

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.7
+FROM ckan/ckan-dev:2.10.8
 
 # Install any extensions needed by your CKAN instance
 # - Make sure to add the plugins to CKAN__PLUGINS in the .env file


### PR DESCRIPTION
https://servicedesk.salsadigital.com.au/a/tickets/6426

It seems we don't need to migrate to `pyproject.toml` yet

![image](https://github.com/user-attachments/assets/530cd979-10d1-43d5-9127-e7704ade90ca)
![image](https://github.com/user-attachments/assets/c01fab2d-11fa-474c-9ad8-fe64208ac906)
