### PR TITLE
Upgrade to CKAN 2.10.8

### DIFF
--- a/.env.dbca
+++ b/.env.dbca
@@ -35,7 +35,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.7
+CKAN_VERSION=2.10.8
 CKAN_SITE_ID=default
 # CKAN Dev
 CKAN_SITE_URL=http://localhost:$CKAN_PORT_HOST

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.7
+CKAN_VERSION=2.10.8
 CKAN_SITE_ID=default
 CKAN_SITE_URL=https://localhost:8443
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ For convenience the CKAN_SITE_URL parameter should be set in the .env file. For 
 
 ## 12. Changing the base image
 
-The base image used in the CKAN Dockerfile and Dockerfile.dev can be changed so a different DockerHub image is used eg: ckan/ckan-base:2.10.5 can be used instead of ckan/ckan-base:2.11.0
+The base image used in the CKAN Dockerfile and Dockerfile.dev can be changed so a different DockerHub image is used eg: ckan/ckan-base:2.10.8 can be used instead of ckan/ckan-base:2.11.0
 
 ## 13. Replacing DataPusher with XLoader
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.7
+FROM ckan/ckan-base:2.10.8
 
 # Install any extensions needed by your CKAN instance
 # See Dockerfile.dev for more details and examples

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.7
+FROM ckan/ckan-dev:2.10.8
 
 # Install any extensions needed by your CKAN instance
 # - Make sure to add the plugins to CKAN__PLUGINS in the .env file

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -75,13 +75,17 @@ ckanext-archiver.cache_url_root=/resource_cache/
 ckanext.qa.qsv_bin=/usr/local/bin/qsv
 
 # ckanext-dbca
+ckan.max_resource_size = 150
+ckanext.dbca.sysadmin_resource_upload_limit = 150
+ckanext.dbca.org_admin_resource_upload_limit = 35
+ckanext.dbca.org_editor_resource_upload_limit = 35
 ckanext.dbca.spatial_data_path = /srv/app/spatial_data
-ckanext.dbca.spatial_data_mappings = 
+ckanext.dbca.spatial_data_mappings =
     {
-        "ibra.geojson": {"layer": "IBRA Regions", "code":"IWA_REG_CODE_7", "name":"IWA_REG_NAME_7"}, 
-        "ibra-sub.geojson": {"layer": "IBRA Subregions", "code":"IWA_SUB_CODE_7", "name":"IWA_SUB_NAME_7"}, 
-        "imcra.geojson": {"layer": "IMCRA Regions", "code": "MESO_ABBR", "name":"MESO_NAME"}, 
-        "lga-wa.geojson": {"layer": " Local Government Areas", "code":"LGA_TYPE", "name":"LGA_LGA_NAME"}, 
+        "ibra.geojson": {"layer": "IBRA Regions", "code":"IWA_REG_CODE_7", "name":"IWA_REG_NAME_7"},
+        "ibra-sub.geojson": {"layer": "IBRA Subregions", "code":"IWA_SUB_CODE_7", "name":"IWA_SUB_NAME_7"},
+        "imcra.geojson": {"layer": "IMCRA Regions", "code": "MESO_ABBR", "name":"MESO_NAME"},
+        "lga-wa.geojson": {"layer": " Local Government Areas", "code":"LGA_TYPE", "name":"LGA_LGA_NAME"},
         "tenure.geojson": {"layer": "DBCA Managed Tenure", "code":"LEG_TENURE", "name":"LEG_NAME"}
     }
 

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -15,6 +15,14 @@ ckan.plugins = dbca saml2auth activity image_view text_view datatables_view pdf_
 ## Resource Views Settings #####################################################
 ckan.views.default_views = image_view text_view datatables_view pdf_view geo_view shp_view officedocs_view
 
+## Uploader Settings ###########################################################
+ckan.upload.user.types = image
+ckan.upload.user.mimetypes = image/png image/gif image/jpeg
+ckan.upload.group.types = image
+ckan.upload.group.mimetypes = image/png image/gif image/jpeg
+ckan.upload.admin.types = image
+ckan.upload.admin.mimetypes = image/png image/gif image/jpeg
+
 ## Internationalisation Settings ###############################################
 ckan.locale_default = en_AU
 ckan.display_timezone = Australia/Perth

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -62,10 +62,16 @@ ckanext.doi.language = en
 # ckanext-showcase
 ckanext.homepage_views = True
 ckanext.showcase.editor = ckeditor
+ckan.upload.showcase.types = image
+ckan.upload.showcase.mimetypes = image/png image/gif image/jpeg
+ckan.upload.showcase_image.types = image
+ckan.upload.showcase_image.mimetypes = image/png image/gif image/jpeg
 
 # ckanext-pages
 ckanext.pages.allow_html = True
 ckanext.pages.editor = ckeditor
+ckan.upload.page_images.types = image
+ckan.upload.page_images.mimetypes = image/png image/gif image/jpeg
 
 # ckanext-archiver
 ckanext-archiver.archive_dir=/var/lib/ckan/archiver

--- a/ckan/setup/dbca_requirements.sh
+++ b/ckan/setup/dbca_requirements.sh
@@ -43,8 +43,12 @@ apk add --no-cache \
     proj-util \
     proj-dev 
 pip3 install -e git+https://github.com/ckan/ckanext-spatial.git@master#egg=ckanext-spatial
-# Incompatibility with Shapely >2 Due to NumPy 2.0 Update https://github.com/ckan/ckanext-spatial/issues/330
-pip3 install "numpy>=1.26,<2"
+# pyproj 3.6.1 in ckanext-spatial requirements.txt is not working
+# Download the CKAN spatial extension requirements file and remove the line pyproj==3.6.1; python_version >= '3.9'
+curl -sSL https://raw.githubusercontent.com/ckan/ckanext-spatial/v2.3.0/requirements.txt \
+    | sed 's/pyproj==3.6.1; python_version >= '\''3.9'\''//g' > ${SRC_DIR}/ckanext-spatial/requirements.txt
+# manually install a later compatible version of pyproj
+pip3 install pyproj==3.7.*
 pip3 install -r ${SRC_DIR}/ckanext-spatial/requirements.txt
 
 # XLoader


### PR DESCRIPTION
This pull request includes updates to CKAN versioning, configuration enhancements for file uploads, and a fix for dependency compatibility issues in the CKAN spatial extension. Below is a categorized summary of the most important changes:

### CKAN Version Update:
* Updated CKAN version from `2.10.7` to `2.10.8` in multiple files, including `.env.dbca`, `.env.example`, `ckan/Dockerfile`, and `ckan/Dockerfile.dev`. This ensures the application is using the latest patch version. [[1]](diffhunk://#diff-0f9ecf57278a460a375662d3129642c8434090c21f4012dab804e513363b7bc2L38-R38) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL30-R30) [[3]](diffhunk://#diff-2255ee862e56fe4f21e684dd00e9f290aebbc3fbb7ac11a56c21ade18cff6f3aL1-R1) [[4]](diffhunk://#diff-b2e36077067a18b5db19a15f820507bf15e816b80363e788edd5a26d5273b611L1-R1)
* Updated the README to reflect the new CKAN base image version `2.10.8`.

### Configuration Enhancements:
* Added support for user, group, admin, and showcase image uploads by specifying allowed types and MIME types in `ckan/config/dbca.ini`. [[1]](diffhunk://#diff-91036d414a77bf981d6fe7b37d215ca30a286b08bd7b64ae27e8228caeb29d72R18-R25) [[2]](diffhunk://#diff-91036d414a77bf981d6fe7b37d215ca30a286b08bd7b64ae27e8228caeb29d72R73-R82)
* Introduced resource upload size limits for different roles (sysadmin, org admin, org editor) and added a new setting for maximum resource size.

### Dependency Compatibility Fix:
* Resolved an issue with the CKAN spatial extension by replacing the problematic `pyproj==3.6.1` dependency with a compatible `pyproj==3.7.*` version. Updated the installation process to dynamically modify the requirements file.