### PR TITLE
Update ckanext-hierarchy dependency to version 1.2.2

### DIFF
--- a/ckan/setup/dbca_requirements.sh
+++ b/ckan/setup/dbca_requirements.sh
@@ -14,7 +14,7 @@ pip3 install -r ${SRC_DIR}/ckanext-dcat/requirements.txt
 pip3 install -e git+https://github.com/ckan/ckanext-geoview.git@v0.1.0#egg=ckanext-geoview
 
 # Hierarchy
-pip3 install -e git+https://github.com/ckan/ckanext-hierarchy.git@v1.2.1#egg=ckanext-hierarchy
+pip3 install -e git+https://github.com/ckan/ckanext-hierarchy.git@v1.2.2#egg=ckanext-hierarchy
 pip3 install -r ${SRC_DIR}/ckanext-hierarchy/requirements.txt
 
 # Pages


### PR DESCRIPTION
This version includes the fix for search-facets on group page: [fix search-facets on group page](https://github.com/ckan/ckanext-hierarchy/pull/69)