### PR TITLE
Release: CKAN upgrade 2.10.10

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -46,6 +46,8 @@ commands:
         CKAN_CONTAINER_NAME=ckan-dev
         WORKER_CONTAINER_NAME=ckan-dev-worker
       fi
+      # Build the base ckan image first so the worker can use it as base image
+      docker compose -f $DOCKER_COMPOSE build "$CKAN_CONTAINER_NAME"
       docker compose -f $DOCKER_COMPOSE build "$@"
 
   cli:

--- a/.env.dbca
+++ b/.env.dbca
@@ -35,7 +35,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.9
+CKAN_VERSION=2.10.10
 CKAN_SITE_ID=default
 # CKAN Dev
 CKAN_SITE_URL=http://localhost:$CKAN_PORT_HOST

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 USE_HTTPS_FOR_DEV=false
 
 # CKAN core
-CKAN_VERSION=2.10.9
+CKAN_VERSION=2.10.10
 CKAN_SITE_ID=default
 CKAN_SITE_URL=https://localhost:8443
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: '[actions] '

--- a/.github/workflows/dbca_build.yml
+++ b/.github/workflows/dbca_build.yml
@@ -24,10 +24,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,18 +35,18 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker ckan image
         id: meta_ckan
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ckan
 
       - name: Extract metadata (tags, labels) for Docker ckan worker image
         id: meta_ckan_worker
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ckan-worker
 
       - name: CKAN Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./ckan
           file: ./ckan/Dockerfile
@@ -54,7 +54,7 @@ jobs:
           tags: ${{ steps.meta_ckan.outputs.tags }}
 
       - name: CKAN Worker Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./ckan
           file: ./ckan/Dockerfile.worker
@@ -70,7 +70,9 @@ jobs:
         run: echo "Using image ref ghcr.io/dbca-wa/ckan-docker-ckan:${{ steps.extract_first_tag.outputs.first_tag }}"
 
       - name: Run Trivy vuln scanner on CKAN image
-        uses: aquasecurity/trivy-action@0.26.0
+        uses: aquasecurity/trivy-action@0.35.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: "image"
           image-ref: ${{ steps.extract_first_tag.outputs.first_tag }}
@@ -80,6 +82,6 @@ jobs:
           output: "trivy-results.sarif"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "trivy-results.sarif"

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ For convenience the CKAN_SITE_URL parameter should be set in the .env file. For 
 
 ## 12. Changing the base image
 
-The base image used in the CKAN Dockerfile and Dockerfile.dev can be changed so a different DockerHub image is used eg: ckan/ckan-base:2.10.9 can be used instead of ckan/ckan-base:2.11.0
+The base image used in the CKAN Dockerfile and Dockerfile.dev can be changed so a different DockerHub image is used eg: ckan/ckan-base:2.10.10 can be used instead of ckan/ckan-base:2.11.0
 
 ## 13. Replacing DataPusher with XLoader
 

--- a/README_DBCA.md
+++ b/README_DBCA.md
@@ -22,12 +22,12 @@
   - The first time the CKAN Dev containers are created the mapped volume will look in the `src:/srv/app/src_extensions` folder to install any extensions cloned from the `ahoy init` step and will pip install the extension and any any requirements file if they exists
 - To see the list of available commands with short descriptions run ahoy
 ```
-ahoy      
+ahoy
 NAME:
    ahoy - Creates a configurable cli app for running commands.
 USAGE:
    ahoy [global options] command [command options] [arguments...]
-   
+
 COMMANDS:
    attach              Attach to a running container
    build               Build project.
@@ -52,9 +52,20 @@ GLOBAL OPTIONS:
    --file value, -f value      Use a specific ahoy file.
    --help, -h                  show help
    --version                   print the version
-   --generate-bash-completion  
-   
+   --generate-bash-completion
+
 VERSION:
    2.0.2-homebrew
-   
-[fatal] Missing flag or argument.```
+
+[fatal] Missing flag or argument.
+```
+
+## How to implement the security patch for the CKAN
+- Run the GH action to generate the image, if not already done. see this https://salsadigital.atlassian.net/wiki/spaces/CKAN/pages/3499819055/CKAN+patching#Upgrade-Salsa-CKAN-Base-Images.
+- Update the image version with latest in below files.
+   - .env.dbca
+   - .env.example
+   - README.md
+   - ckan/Dockerfile
+   - ckan/Dockerfile.dev
+- Run the build and make sure all patches are applied cleanly ckan/patches

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.9
+FROM ckan/ckan-base:2.10.10
 
 # Install any extensions needed by your CKAN instance
 # See Dockerfile.dev for more details and examples

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.9
+FROM ckan/ckan-dev:2.10.10
 
 # Install any extensions needed by your CKAN instance
 # - Make sure to add the plugins to CKAN__PLUGINS in the .env file

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -9,6 +9,20 @@
 use = config:/srv/app/ckan.ini
 ckan.devserver.watch_patterns = /srv/app/ckan.ini
 
+## SQLAlchemy engine / pool tuning #############################################
+# Validate connections at checkout to detect ones killed by the DB / network.
+# Eliminates the "stale connection in pool" half of the cascading-failure pattern.
+sqlalchemy.pool_pre_ping = True
+# Recycle connections older than 30 minutes (well under typical NAT/idle timeouts
+# and Postgres idle_session_timeout if it ever gets enabled).
+sqlalchemy.pool_recycle = 1800
+# Per-worker pool sizing. Each gunicorn worker has its own pool, so the real
+# ceiling = WORKERS * pods * (pool_size + max_overflow). Keep well under the
+# Postgres max_connections of 1718 you confirmed.
+sqlalchemy.pool_size = 10
+sqlalchemy.max_overflow = 20
+sqlalchemy.pool_timeout = 30
+
 ## Plugins Settings ############################################################
 ckan.plugins = dbca saml2auth activity image_view text_view datatables_view pdf_view geo_view shp_view officedocs_view resource_proxy datastore xloader pages showcase hierarchy_display hierarchy_form hierarchy_group_form dcat scheming_datasets spatial_metadata spatial_query doi qa archiver report envvars
 

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -23,10 +23,6 @@ sqlalchemy.pool_size = 10
 sqlalchemy.max_overflow = 20
 sqlalchemy.pool_timeout = 30
 
-## Cache Settings ###############################################################
-ckan.cache_enabled = true
-ckan.cache_expires = 3600
-
 ## Plugins Settings ############################################################
 ckan.plugins = dbca saml2auth activity image_view text_view datatables_view pdf_view geo_view shp_view officedocs_view resource_proxy datastore xloader pages showcase hierarchy_display hierarchy_form hierarchy_group_form dcat scheming_datasets spatial_metadata spatial_query doi qa archiver report envvars
 

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -36,6 +36,7 @@ ckan.auth.user_create_groups = false
 ckan.auth.user_create_organizations = false
 ckan.auth.user_delete_groups = false
 ckan.auth.user_delete_organizations = false
+ckan.auth.allow_dataset_collaborators = true
 
 ## Activity Streams Settings ###################################################
 ckan.activity_streams_email_notifications = true

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -23,6 +23,10 @@ sqlalchemy.pool_size = 10
 sqlalchemy.max_overflow = 20
 sqlalchemy.pool_timeout = 30
 
+## Cache Settings ###############################################################
+ckan.cache_enabled = true
+ckan.cache_expires = 3600
+
 ## Plugins Settings ############################################################
 ckan.plugins = dbca saml2auth activity image_view text_view datatables_view pdf_view geo_view shp_view officedocs_view resource_proxy datastore xloader pages showcase hierarchy_display hierarchy_form hierarchy_group_form dcat scheming_datasets spatial_metadata spatial_query doi qa archiver report envvars
 

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -50,7 +50,7 @@ ckan.auth.user_create_groups = false
 ckan.auth.user_create_organizations = false
 ckan.auth.user_delete_groups = false
 ckan.auth.user_delete_organizations = false
-ckan.auth.allow_dataset_collaborators = false
+ckan.auth.allow_dataset_collaborators = true
 
 ## Activity Streams Settings ###################################################
 ckan.activity_streams_email_notifications = true

--- a/ckan/config/dbca.ini
+++ b/ckan/config/dbca.ini
@@ -50,7 +50,7 @@ ckan.auth.user_create_groups = false
 ckan.auth.user_create_organizations = false
 ckan.auth.user_delete_groups = false
 ckan.auth.user_delete_organizations = false
-ckan.auth.allow_dataset_collaborators = true
+ckan.auth.allow_dataset_collaborators = false
 
 ## Activity Streams Settings ###################################################
 ckan.activity_streams_email_notifications = true


### PR DESCRIPTION
## Summary

- **[SD-8484](https://servicedesk.salsadigital.com.au/a/tickets/8484) CKAN Upgrade**: Updated CKAN to the latest patch version 2.10.10
- **[SD-8383](https://servicedesk.salsadigital.com.au/a/tickets/8383) Dataset collaborators**: Enabled `ckan.auth.allow_dataset_collaborators = true` in `dbca.ini`.
- **[SD-8386](https://servicedesk.salsadigital.com.au/a/tickets/8386) SQLAlchemy connection pooling**: Added pool tuning settings (`pool_pre_ping`, `pool_recycle = 1800`, `pool_size = 10`, `max_overflow = 20`, `pool_timeout = 30`) to prevent stale connection failures.
- **GitHub Actions upgrades**: Bumped all workflow action versions (`actions/checkout` v4→v6, `docker/login-action` v3→v4, `docker/metadata-action` v5→v6, `docker/build-push-action` v5→v7, `aquasecurity/trivy-action` 0.26.0→0.35.0, `github/codeql-action/upload-sarif` v3→v4). Added `TRIVY_DB_REPOSITORY` env var pointing to the ECR mirror to resolve Trivy DB pull failures.
- **Dependabot**: Added `.github/dependabot.yml` to track GitHub Actions dependency updates weekly.
- **CKAN worker base image build**: Updated `.ahoy.yml` to explicitly build the CKAN base image before the worker image so the worker `Dockerfile` can use it as its base.

## Related

- Extension changes: https://github.com/dbca-wa/ckanext-dbca/pull/22
  - [SD-8383](https://servicedesk.salsadigital.com.au/a/tickets/8383)
  - [SD-8379](https://servicedesk.salsadigital.com.au/a/tickets/8379)