### PR TITLE
Harden CKAN images and Trivy scan config

### DIFF
--- a/.github/workflows/dbca_build.yml
+++ b/.github/workflows/dbca_build.yml
@@ -98,6 +98,11 @@ jobs:
           image-ref: ${{ steps.extract_first_tag.outputs.first_tag }}
           vuln-type: "os,library"
           severity: "HIGH,CRITICAL"
+          # Skip OS packages with no upstream fix available (they reappear once
+          # Debian ships one)
+          ignore-unfixed: "true"
+          # Without this the severity filter above is not applied to SARIF output
+          limit-severities-for-sarif: "true"
           format: "sarif"
           output: "trivy-results.sarif"
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -4,13 +4,24 @@ FROM ckan/ckan-base:2.11.6
 # dir; ckan runs the process). Install as root, drop back to ckan at the end.
 USER root
 
+# --- PATCH SECTION START ---
+# Debian security updates on top of the pinned base, minus the kernel headers it
+# installs (a container never uses them).
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    apt-get purge -y 'linux-headers-*' 'linux-kbuild-*' 'linux-compiler-gcc-*' && \
+    apt-get autoremove -y --purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+# --- PATCH SECTION END ---
+
 # ===== DBCA: install extensions (expensive layer; changes rarely vs config) =====
 # dbca_requirements.sh handles its own apt/pip deps, incl. xmlsec1 for saml2auth.
 # CKANEXT_DBCA_REF pins the ckanext-dbca git ref; CI passes a tag/SHA for releases
 # so master builds don't track a moving branch (defaults to develop for local builds).
 ARG CKANEXT_DBCA_REF=develop
 ENV CKANEXT_DBCA_REF=${CKANEXT_DBCA_REF}
-COPY setup/dbca_requirements.sh ${APP_DIR}
+COPY setup/dbca_requirements.sh setup/dbca_requirements.txt ${APP_DIR}
 RUN chmod +x ${APP_DIR}/dbca_requirements.sh && \
     ${APP_DIR}/dbca_requirements.sh
 # chown site-packages next to the install so it caches with it, rather than being
@@ -35,6 +46,20 @@ COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches
 # Re-assert app-dir ownership after the root COPY steps (cheap; site-packages
 # was already chowned above)
 RUN chown -R ckan:ckan-sys $APP_DIR
+
+# --- RUNTIME SLIM START ---
+# Drop build-only toolchain, -dev packages (from the base and dbca_requirements.sh)
+# and pip. Keeps runtime libs the extensions need, wget (compose healthcheck), patch (step below).
+# Production only: Dockerfile.dev keeps the toolchain for runtime pip installs.
+RUN keep="libpq5 file libmagic1 libgeos-c1v5 libproj25 xmlsec1 wget patch"; \
+    for p in $keep; do dpkg -s "$p" >/dev/null 2>&1 && apt-mark manual "$p"; done; \
+    drop=""; for p in git unzip g++ gcc cpp binutils libtool libpq-dev libgeos-dev libproj-dev proj-bin libc6-dev linux-libc-dev libssl-dev; do \
+        dpkg -s "$p" >/dev/null 2>&1 && drop="$drop $p"; done; \
+    DEBIAN_FRONTEND=noninteractive apt-get purge -y $drop && \
+    apt-get autoremove -y --purge && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /root/.cache/pip && \
+    pip3 uninstall -y pip
+# --- RUNTIME SLIM END ---
 
 USER ckan
 

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -35,13 +35,24 @@ FROM ckan/ckan-dev:2.11.6
 # dir; ckan runs the process). Install as root, drop back to ckan at the end.
 USER root
 
+# --- PATCH SECTION START ---
+# Debian security updates on top of the pinned base, minus the kernel headers it
+# installs (a container never uses them).
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    apt-get purge -y 'linux-headers-*' 'linux-kbuild-*' 'linux-compiler-gcc-*' && \
+    apt-get autoremove -y --purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+# --- PATCH SECTION END ---
+
 # ===== DBCA: install extensions (expensive layer; changes rarely vs config) =====
 # dbca_requirements.sh handles its own apt/pip deps, incl. xmlsec1 for saml2auth.
 # CKANEXT_DBCA_REF pins the ckanext-dbca git ref; CI passes a tag/SHA for releases
 # so master builds don't track a moving branch (defaults to develop for local builds).
 ARG CKANEXT_DBCA_REF=develop
 ENV CKANEXT_DBCA_REF=${CKANEXT_DBCA_REF}
-COPY setup/dbca_requirements.sh ${APP_DIR}
+COPY setup/dbca_requirements.sh setup/dbca_requirements.txt ${APP_DIR}
 RUN chmod +x ${APP_DIR}/dbca_requirements.sh && \
     ${APP_DIR}/dbca_requirements.sh
 # chown site-packages next to the install so it caches with it, rather than being

--- a/ckan/setup/dbca_requirements.sh
+++ b/ckan/setup/dbca_requirements.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Latest pip before installing anything below
+pip3 install -U pip
+
 ## Process management ##
 # supervisor runs the CKAN job workers (not shipped by the Debian base). Installed
 # here so the worker image and the shared dev site-packages volume both have it.
@@ -87,3 +90,6 @@ pip3 install -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@53180596
 # Ref is build-time configurable so releases can pin an immutable tag/SHA instead
 # of a moving branch. Defaults to develop for local/dev builds; CI sets it per branch.
 pip3 install -e git+https://github.com/dbca-wa/ckanext-dbca.git@${CKANEXT_DBCA_REF:-develop}#egg=ckanext-dbca
+
+## Project-level pins (see dbca_requirements.txt) ##
+pip3 install -r "$(dirname "$0")/dbca_requirements.txt"

--- a/ckan/setup/dbca_requirements.txt
+++ b/ckan/setup/dbca_requirements.txt
@@ -1,0 +1,14 @@
+# Project-level Python pins, installed last by dbca_requirements.sh so they override
+# CKAN core / extension requirements. Justify each; drop it once upstream catches up.
+#
+# setuptools: CKAN base pins <82 (ckan/ckan#9246).
+
+sqlparse==0.6.0  # CKAN pins 0.5.4 (CVEs, unfixed); nothing in CKAN imports it
+
+# Deliberately past pysaml2's pyopenssl cap (pip warns; install still succeeds).
+# The cap guards pyOpenSSL APIs pysaml2 uses only for cert-chain verification
+# (verify_cert, off by default) and cert generation - neither is used here. The
+# login path (load_certificate, validity check) was tested on this pair; retest SSO
+# login after any bump.
+pyOpenSSL==26.4.0
+cryptography==50.0.1


### PR DESCRIPTION
Cuts the Trivy findings on the CKAN 2.11 image down to zero and fixes the scanner config so the GitHub Security tab only shows what the workflow was meant to show. Based on `feature/ckan-2.11.6`, so the diff here is just the hardening work.

## Background

When CKAN 2.11 first went into develop (#28) the Security tab lit up with thousands of Trivy findings and the merge was reverted (#29). Digging into it, there were two separate problems:

1. The upstream `ckan/ckan-base` image installs a compiler toolchain and Linux kernel headers so it can build CKAN, and never cleans them up. The kernel headers alone were about 90% of the findings, and a container never uses them.
2. The workflow sets `severity: HIGH,CRITICAL`, but trivy-action doesn't apply that to SARIF output unless `limit-severities-for-sarif` is also set. So the Security tab was getting every severity, including LOW, MEDIUM and UNKNOWN.

## Results

Scanned with the same Trivy version, database mirror and settings as the workflow, on the `ckan/ckan-base:2.11.6` image built from the production Dockerfile in this repo (`linux/amd64`, same as CI):

| | HIGH + CRITICAL | Security tab (all severities) |
|---|---|---|
| Before this PR | 1,074 | 9,067 |
| Image changes only | 49 | 338 |
| Image changes plus scanner config | 0 | 0 |

The 49 HIGH/CRITICAL findings left in the image have no fix available from Debian (perl-base, sqlite, zlib, util-linux, libxml2 — all part of the official `python:3.10-slim` base). `ignore-unfixed` takes them out of the report, and they come back on their own once Debian ships a fix.

## Image changes

Patch section (`Dockerfile` and `Dockerfile.dev`): applies Debian security updates on top of the pinned base and removes the kernel-header packages. The base is only rebuilt on CKAN patch releases, so this keeps the OS packages current in between.

Runtime slim (`Dockerfile`, production only): once the extensions are installed, removes what was only needed to build them — gcc/g++/binutils, the `-dev` packages, `git` (which drags in the full Perl stack), `unzip` and `pip`. The runtime libraries the extensions need stay (`libpq5`, `file`/`libmagic1`, geos/proj, `xmlsec1`, `wget` for the healthcheck, `patch`). The dev image keeps the toolchain because it installs packages at runtime.

Project-level pins (`setup/dbca_requirements.txt`, installed last by `dbca_requirements.sh` so they win over CKAN core and extension requirements):

- `sqlparse` 0.5.4 → 0.6.0. CKAN core pins 0.5.4, but nothing in CKAN or our extensions actually imports it.
- `pyOpenSSL` 24.2.1 → 26.4.0 and `cryptography` 43.0.3 → 50.0.1. These go past the `pyopenssl<24.3` cap that `pysaml2` declares (pip warns about it but the install succeeds). That cap protects pyOpenSSL APIs pysaml2 only uses for optional certificate-chain verification (`verify_cert`, off by default and not set by ckanext-saml2auth) and for generating certificates, neither of which we use. The login path (`load_certificate` and the validity check) was tested against the pinned pair. SSO login needs to be retested once this is deployed.

`dbca_requirements.sh` now also upgrades pip before it installs anything.

## Scanner config changes (`.github/workflows/dbca_build.yml`)

Two settings added to the Trivy step. Calling them out here so the reasoning is on record:

- `ignore-unfixed: "true"` — drops vulnerabilities where the distribution has no patched package yet. Nothing is suppressed by CVE ID; a finding reappears as soon as a fix is published. This is the usual setting for Debian-based images, and without it the report is mostly things nobody can act on.
- `limit-severities-for-sarif: "true"` — makes the existing `severity: HIGH,CRITICAL` filter apply to the SARIF upload. It doesn't change what gets scanned, only what the filter that was already configured actually covers.

There's no `.trivyignore` file and no individual CVE is suppressed.

## Verification

- Production and dev images build. psycopg2, lxml, libmagic, shapely, sqlparse and CKAN all import; `file`, `xmlsec1`, `qsv`, `patch` and `wget` are present; the `ckan` CLI loads every plugin; pip and the toolchain are confirmed gone from the production image.
- pysaml2 login-path test passes on pyOpenSSL 26.4.0 / cryptography 50.0.1.
- The Trivy step was run locally with `act` using the exact workflow inputs: 0 SARIF results.
- The workflow was then run manually on this branch ([run 33157782894](https://github.com/dbca-wa/ckan-docker/actions/runs/33157782894)). Build, scan and upload all succeeded, and the Security tab analysis for `7751168` has 0 results and 0 open alerts. For comparison, develop currently has 45 open Trivy alerts and master has 40.
- Socket's supply-chain checks on the PR pass, with the three pinned packages scoring 100 across the board.
