### PR TITLE
Limit GITHUB_TOKEN permissions in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs: 
   build:  
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the one remaining open code-scanning alert (#83, CodeQL `actions/missing-workflow-permissions`). `build.yml` only checks out and runs `push: false` image builds, so `contents: read` is sufficient. `dbca_build.yml` already sets job-level permissions and is unaffected.