### PR TITLE
Fix CKAN 2.11 cron job commands and restore psql in the images

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "module": "pdb",
             "args": [
                 "-c continue",
-                "/usr/bin/ckan",
+                "/usr/local/bin/ckan",
                 "--config",
                 "/srv/app/config/dbca.ini",
                 "run",
@@ -28,7 +28,7 @@
             "module": "pdb",
             "args": [
                 "-c continue",
-                "/usr/bin/ckan",
+                "/usr/local/bin/ckan",
                 "--config",
                 "/srv/app/config/dbca.ini",
                 "jobs",
@@ -43,7 +43,7 @@
             "module": "pdb",
             "args": [
                 "-c continue",
-                "/usr/bin/ckan",
+                "/usr/local/bin/ckan",
                 "--config",
                 "/srv/app/config/dbca.ini",
                 "<CLI_COMMAND>"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    // src/ckanext-dbca is its own git checkout, two levels below the workspace
+    // root. The default repository scan depth of 1 never finds it, so it does
+    // not appear in Source Control.
+    "git.repositoryScanMaxDepth": 2
+}

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -49,7 +49,7 @@ RUN chown -R ckan:ckan-sys $APP_DIR
 # Drop build-only toolchain, -dev packages (from the base and dbca_requirements.sh)
 # and pip. Keeps runtime libs the extensions need, wget (compose healthcheck), patch (step below).
 # Production only: Dockerfile.dev keeps the toolchain for runtime pip installs.
-RUN keep="libpq5 file libmagic1 libgeos-c1v5 libproj25 xmlsec1 wget patch"; \
+RUN keep="libpq5 postgresql-client file libmagic1 libgeos-c1v5 libproj25 xmlsec1 wget patch"; \
     for p in $keep; do dpkg -s "$p" >/dev/null 2>&1 && apt-mark manual "$p"; done; \
     drop=""; for p in git unzip g++ gcc cpp binutils libtool libpq-dev libgeos-dev libproj-dev proj-bin libc6-dev linux-libc-dev libssl-dev; do \
         dpkg -s "$p" >/dev/null 2>&1 && drop="$drop $p"; done; \

--- a/ckan/setup/dbca_ckan_cron_jobs
+++ b/ckan/setup/dbca_ckan_cron_jobs
@@ -9,4 +9,6 @@
 # Send CKAN email notifications -- 00:00 UTC = 08:00 AWST
 0 0 * * * /usr/local/bin/ckan -c /srv/app/config/dbca.ini notify send_emails
 # dbca logs maintenance -- 16:00 UTC = 00:00 AWST
+# Only does anything while ckanext.dbca.enable_db_logging is true; it is off by
+# default, so dbca_logs is normally empty and this is a no-op.
 0 16 * * * /usr/bin/psql $CKAN_SQLALCHEMY_URL -f /srv/app/dbca_logs_maintenance.sql

--- a/ckan/setup/dbca_ckan_cron_jobs
+++ b/ckan/setup/dbca_ckan_cron_jobs
@@ -1,7 +1,12 @@
-# Crontab for CKAN cron jobs
-# 8am task to schedule embargo datasets to public visibility
-0 8 * * * /usr/local/bin/ckan -c /srv/app/config/dbca.ini dbca scheduled_datasets
-# 8am task to send CKAN email notifications
-0 8 * * * /usr/local/bin/ckan -c /srv/app/config/dbca.ini notify send_emails
-# Midnight dbca logs maintenance
-0 0 * * * psql $CKAN_SQLALCHEMY_URL -f /srv/app/dbca_logs_maintenance.sql
+# Reference only, not deployed. The real schedule is the Kubernetes CronJobs in
+# the `ckan` namespace (embargo-dataset, email-notification, log-maintenance),
+# running the ckan-worker image. Keep this file in step with them: schedules
+# below are UTC to match, since the CronJobs have no spec.timeZone.
+# CronJob pods also need CKAN___SECRET_KEY and runAsUser: 503, or the command aborts.
+
+# Schedule embargo datasets to public visibility -- 00:00 UTC = 08:00 AWST
+0 0 * * * /usr/local/bin/ckan -c /srv/app/config/dbca.ini dbca scheduled_datasets
+# Send CKAN email notifications -- 00:00 UTC = 08:00 AWST
+0 0 * * * /usr/local/bin/ckan -c /srv/app/config/dbca.ini notify send_emails
+# dbca logs maintenance -- 16:00 UTC = 00:00 AWST
+0 16 * * * /usr/bin/psql $CKAN_SQLALCHEMY_URL -f /srv/app/dbca_logs_maintenance.sql

--- a/ckan/setup/dbca_requirements.sh
+++ b/ckan/setup/dbca_requirements.sh
@@ -94,7 +94,7 @@ pip3 install -e git+https://github.com/salsadigitalauorg/ckanext-saml2auth.git@s
 # Pinned to an immutable SHA like every other extension above, so the production
 # image is reproducible. The dev image overrides CKANEXT_DBCA_REF to develop
 # (see Dockerfile.dev) so local work tracks the branch.
-pip3 install -e git+https://github.com/dbca-wa/ckanext-dbca.git@${CKANEXT_DBCA_REF:-7414d3a90ec365b60e575c4bdc40c736d04a99a2}#egg=ckanext-dbca
+pip3 install -e git+https://github.com/dbca-wa/ckanext-dbca.git@${CKANEXT_DBCA_REF:-1161b3000b65407f70d21954868faccf44e28b2a}#egg=ckanext-dbca
 
 ## Project-level pins (see dbca_requirements.txt) ##
 pip3 install -r "$(dirname "$0")/dbca_requirements.txt"

--- a/ckan/setup/dbca_requirements.sh
+++ b/ckan/setup/dbca_requirements.sh
@@ -8,6 +8,10 @@ pip3 install -U pip
 # here so the worker image and the shared dev site-packages volume both have it.
 pip3 install supervisor
 
+## Database client ##
+# psql for the log-maintenance cron job and for reaching the DB from a container.
+apt-get update && apt-get install -y --no-install-recommends postgresql-client
+
 ## CKAN Core extensions ##
 
 # Archiver


### PR DESCRIPTION
Companion to dbca-wa/ckanext-dbca#27.

All three CronJobs in the `ckan` namespace run commands that no longer exist in
the 2.11.6 image, so none of them have run since the upgrade:

| CronJob | Problem |
|---|---|
| `embargo-dataset` | `/usr/bin/ckan` moved to `/usr/local/bin/ckan` with the Debian base |
| `email-notification` | same |
| `log-maintenance` | `psql` is not installed |

## Changes

- `ckan/setup/dbca_ckan_cron_jobs` — corrected commands, and a header noting the
  file is a non-deployed reference for the AKS CronJobs. Nothing reads it, which
  is how the 2.11 change was missed. Schedules in UTC to match, AWST in comments.
- `ckan/setup/dbca_requirements.sh` — install `postgresql-client`. The
  maintenance SQL is multi-statement and ends in `VACUUM`, which cannot run in a
  transaction, so `psql` rather than a psycopg2 shim.
- `ckan/Dockerfile` — keep it through the runtime-slim purge, which kept only
  `libpq5`, the library rather than the client.
- `ckan/setup/dbca_requirements.sh` — bump ckanext-dbca to `1161b30`, the merge
  commit of #27, so the embargo date fix ships with these.
- `.vscode/launch.json` — same stale `/usr/bin/ckan` path in 3 debug configs.
- `.vscode/settings.json` — new. `src/ckanext-dbca` is its own checkout two
  levels down, and the editors' default repository scan depth of 1 never found
  it, so it never appeared in Source Control.

Verified against a rebuilt production image: `ckan` and `ckan-worker` build
clean, the pin resolves to `1161b30`, and `psql` and `/usr/local/bin/ckan` are
both present. All three cron commands exit 0.

The AKS CronJob manifests carry the same stale commands and need the same
change — that is where the real schedule lives.
